### PR TITLE
Added a way to wrap an already created AppDomain in an AppDomainToolkit.AppDomainContext

### DIFF
--- a/AppDomainToolkit.UnitTests/AppDomainContextUnitTests.cs
+++ b/AppDomainToolkit.UnitTests/AppDomainContextUnitTests.cs
@@ -110,6 +110,20 @@
             Assert.AreEqual(setupInfo.PrivateBinPath, target.Domain.SetupInformation.PrivateBinPath);
         }
 
+        [TestMethod]
+        public void Create_NoApplicationNameSupplied_WrappedDomain()
+        {
+            var target = AppDomainContext.Wrap(AppDomain.CurrentDomain);
+
+            Assert.IsNotNull(target);
+            Assert.IsNotNull(target.Domain);
+            Assert.IsNotNull(target.UniqueId);
+            Assert.IsNotNull(target.RemoteResolver);
+            Assert.AreEqual(AppDomain.CurrentDomain, target.Domain);
+
+            // Verify the app domain's setup info
+            Assert.IsFalse(string.IsNullOrEmpty(target.Domain.SetupInformation.ApplicationName));
+        }
         #endregion
 
         #region Dispose


### PR DESCRIPTION
In one of my projects which uses AppDomainToolkit I want a quick and easy way to turn _off_ using AppDomains and just to load everything into the main domain.

This PR seems to be the easiest way to do this, it allows me to keep all my code the same except where I create the domain I just switch:

```
_context = AppDomainContext.Create();
```

To:

```
_context = _pluginContext = AppDomainContext.Wrap(AppDomain.Current);
```

Does this seem like a sensible thing to be doing?

Signed-off-by: Martin Evans martindevans@gmail.com
