### PR TITLE
Add methods to remove probe paths from resolver

### DIFF
--- a/AppDomainToolkit/PathBasedAssemblyResolver.cs
+++ b/AppDomainToolkit/PathBasedAssemblyResolver.cs
@@ -1,4 +1,6 @@
-﻿namespace AppDomainToolkit
+﻿using System.Linq;
+
+namespace AppDomainToolkit
 {
     using System;
     using System.Collections.Generic;
@@ -126,6 +128,37 @@
                 {
                     this.probePaths.Add(dir.FullName);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Removes the given probe path or semicolon separated list of probe paths from the assembly loader.
+        /// </summary>
+        /// <param name="path">The path to remove.</param>
+        public void RemoveProbePath(string path)
+        {
+            if (String.IsNullOrEmpty(path)) return;
+
+            if (path.Contains(";"))
+            {
+                var paths = path.Split(new[] {";"}, StringSplitOptions.RemoveEmptyEntries);
+
+                RemoveProbePaths(paths);
+            }
+            else RemoveProbePaths(path);
+        }
+
+        /// <summary>
+        /// Removes the given probe paths from the assembly loader.
+        /// </summary>
+        /// <param name="paths">The paths to remove.</param>
+        public void RemoveProbePaths(params string[] paths)
+        {
+            foreach (var dir in from path in paths
+                                where !String.IsNullOrEmpty(path)
+                                select new DirectoryInfo(path))
+            {
+                probePaths.Remove(dir.FullName);
             }
         }
 


### PR DESCRIPTION
I'm finding it necessary at runtime to remove probe paths from my remote resolver, particularly the application base path. This is to prevent loading dependent assemblies from the application base path if my remote assemblies depend on a different version of the same assembly (e.g. newer version of Common.Logging, etc.), which has caused a lot of issues with our plugin architecture. It's not possible to disable probing the application base path in this scenario as the base path needs to be probed to locate AppDomainToolkit itself.

Example usage with an instantiated app:
```csharp
var appDomainContext =
   AppDomainContext.Create(new AppDomainSetup
   {
      ApplicationName = pluginName,
      ApplicationBase = basePath,
      CachePath = pluginDir,
      ConfigurationFile = configFile,
      PrivateBinPath = pluginDir
   }));

var loader = appDomainContext.RemoteResolver as PathBasedAssemblyResolver;
if (loader != null) loader.RemoveProbePath(basePath);
// Now safe to load our plugin without conflicts
appDomainContext.LoadAssemblyWithReferences(LoadMethod.LoadFile, pluginPath);
```

Also note that the diff is messy, it appears that this file must not have had normalized line endings prior to the addition of text=auto to the .gitattributes file. Changes start [here](https://github.com/RoadRanger/AppDomainToolkit/commit/4c9798d4f824ffc2868437dc4e1e45a8084768fb#diff-3f05958a5d10bf31428596446db5e574R138).