### PR TITLE
Fix execution assembly path in case of AppDomain recursion

### DIFF
--- a/AppDomainToolkit.UnitTests/AppDomainContextUnitTests.cs
+++ b/AppDomainToolkit.UnitTests/AppDomainContextUnitTests.cs
@@ -54,7 +54,7 @@
         [Fact]
         public void Create_ValidSetupInfo()
         {
-            var workingDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var workingDir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
             var setupInfo = new AppDomainSetup()
             {
                 ApplicationName = "My app",
@@ -79,7 +79,7 @@
         [Fact]
         public void Create_NoApplicationNameSupplied()
         {
-            var workingDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var workingDir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
             var setupInfo = new AppDomainSetup()
             {
                 ApplicationBase = workingDir,

--- a/AppDomainToolkit.UnitTests/AppDomainToolkit.UnitTests.csproj
+++ b/AppDomainToolkit.UnitTests/AppDomainToolkit.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0-rc4-build1049\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc4-build1049\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.0.0-rc4-build2924\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0-rc4-build2924\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,7 +17,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>d53394a4</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>a07563e5</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,21 +45,24 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq">
-      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.2.1502.911, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\packages\xunit.abstractions.2.0.0-rc3-build2880\lib\net35\xunit.abstractions.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0-rc4-build2924\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\packages\xunit.assert.2.0.0-rc3-build2880\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.0.0.2924, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\xunit.assert.2.0.0-rc4-build2924\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0-rc3-build2880\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.0.0.2924, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\xunit.extensibility.core.2.0.0-rc4-build2924\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -106,8 +109,8 @@
     <PropertyGroup>
       <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Activez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est le suivant : {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.0.0-rc4-build2924\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0-rc4-build2924\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc4-build1049\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0-rc4-build1049\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/AppDomainToolkit.UnitTests/RemoteFuncAsyncUnitTests.cs
+++ b/AppDomainToolkit.UnitTests/RemoteFuncAsyncUnitTests.cs
@@ -8,6 +8,11 @@
 
     public class RemoteFuncAsyncUnitTests
     {
+        static RemoteFuncAsyncUnitTests()
+        {
+            
+        }
+
         [Fact]
         public async Task NullDomain()
         {

--- a/AppDomainToolkit.UnitTests/packages.config
+++ b/AppDomainToolkit.UnitTests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.0.10827" targetFramework="net40" />
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0-rc3-build1046" targetFramework="net45" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="xunit" version="2.0.0-rc4-build2924" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc4-build2924" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc4-build2924" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc4-build2924" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc4-build2924" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0-rc4-build1049" targetFramework="net45" />
 </packages>

--- a/AppDomainToolkit/AppDomainContext.cs
+++ b/AppDomainToolkit/AppDomainContext.cs
@@ -91,14 +91,8 @@ namespace AppDomainToolkit
                 ApplicationBase = setupInfo.ApplicationBase,
                 PrivateBinPath = setupInfo.PrivateBinPath
             };
-
-            // Retreive parent AppDomain missing info with XUnit
-            setupInfo.ApplicationBase = AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
-            setupInfo.ApplicationName = AppDomain.CurrentDomain.SetupInformation.ApplicationName;
-            setupInfo.ApplicationTrust = AppDomain.CurrentDomain.SetupInformation.ApplicationTrust;
-
+ 
             // Add some root directories to resolve some required assemblies
-
             // Create the new domain and wrap it for disposal.
             this.wrappedDomain = new DisposableAppDomain(createDomain(setupInfo, UniqueId.ToString()));
 
@@ -215,7 +209,10 @@ namespace AppDomainToolkit
             where TNewAssemblyResolver : MarshalByRefObject, TAssemblyResolver, IAssemblyResolver, new()
         {
             var guid = Guid.NewGuid();
-            var rootDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            //string rootDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string rootDir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+
             var setupInfo = new AppDomainSetup()
             {
                 ApplicationName = "Temp-Domain-" + guid,


### PR DESCRIPTION
Here's the fix for correctly setting the AppDomainSetup path in AppDomainContext.Create() method.
I set it from Assembly.GetExecutingAssembly().CodeBase instead of Assembly.GetExecutingAssembly().Location.
This pull includes all the Async Func + the upgraded XUnit version of the test project.