### PR TITLE
Fix AssemblyTarget for dynamic assemblies.

### DIFF
--- a/AppDomainToolkit/AssemblyTarget.cs
+++ b/AppDomainToolkit/AssemblyTarget.cs
@@ -34,6 +34,9 @@
         /// <inheritdoc />
         public string FullName { get; private set; }
 
+        /// <inheritdoc />
+        public bool IsDynamic { get; private set; }
+
         #endregion
 
         #region Public Methods
@@ -54,8 +57,15 @@
                 throw new ArgumentNullException("assembly");
             }
 
-            var uri = new Uri(assembly.CodeBase);
-            return FromPath(uri, assembly.Location, assembly.FullName);
+            if (assembly.IsDynamic)
+            {
+                return FromDynamic(assembly.FullName);
+            }
+            else
+            {
+                var uri = new Uri(assembly.CodeBase);
+                return FromPath(uri, assembly.Location, assembly.FullName);
+            }
         }
 
         /// <summary>
@@ -77,7 +87,7 @@
         {
             if (codebase == null)
             {
-                throw new ArgumentNullException("Codebase URI cannot be null!");
+                throw new ArgumentNullException("codebase", "Codebase URI cannot be null!");
             }
 
             if (!File.Exists(codebase.LocalPath))
@@ -94,7 +104,33 @@
             {
                 CodeBase = codebase,
                 Location = location,
-                FullName = fullname
+                FullName = fullname,
+                IsDynamic = false,
+            };
+        }
+
+        /// <summary>
+        /// Creates a new assembly target for the given dynamic assembly.
+        /// </summary>
+        /// <param name="fullName">
+        /// The full name of the assembly.
+        /// </param>
+        /// <returns>
+        /// An AssemblyTarget.
+        /// </returns>
+        public static IAssemblyTarget FromDynamic(string fullName)
+        {
+            if (fullName == null)
+            {
+                throw new ArgumentNullException("fullName", "FullName cannot be null!");
+            }
+
+            return new AssemblyTarget()
+            {
+                CodeBase = null,
+                Location = null,
+                FullName = fullName,
+                IsDynamic = true
             };
         }
 

--- a/AppDomainToolkit/IAssemblyTarget.cs
+++ b/AppDomainToolkit/IAssemblyTarget.cs
@@ -12,11 +12,13 @@ namespace AppDomainToolkit
 
         /// <summary>
         /// Gets the location of the code base on disk.
+        /// Can be null if the assembly is dynamic
         /// </summary>
         Uri CodeBase { get; }
 
         /// <summary>
         /// Gets the location of the assembly, if applicable.
+        /// Can be null if the assembly is dynamic
         /// </summary>
         string Location { get; }
 
@@ -24,6 +26,12 @@ namespace AppDomainToolkit
         /// Gets the full name of the assembly target.
         /// </summary>
         string FullName { get; }
+
+        /// <summary>
+        /// Indicates if the assembly is dynamic.
+        /// If true, CodeBase and Location will be null.
+        /// </summary>
+        bool IsDynamic { get; }
 
         #endregion
     }


### PR DESCRIPTION
AssemblyTarget throws exception in case the assembly is dynamic. This fix allows you to query all the assemblies of a given AppDomain even if some of them are dynamic.