### PR TITLE
#25 Use activator instead of createinstance and unwrap.

### DIFF
--- a/AppDomainToolkit/Remote.cs
+++ b/AppDomainToolkit/Remote.cs
@@ -110,15 +110,18 @@
 
             var type = typeof(T);
 
-            var proxy = (T)wrappedDomain.Domain.CreateInstanceAndUnwrap(
-                type.Assembly.FullName,
+            var proxyHandle = Activator.CreateInstance(
+                wrappedDomain.Domain,
+                type.Assembly.GetName().Name,
                 type.FullName,
                 false,
-                BindingFlags.CreateInstance,
+                BindingFlags.CreateInstance, 
                 null,
                 constructorArgs,
                 null,
                 null);
+
+            var proxy = (T) proxyHandle.Unwrap();
 
             return new Remote<T>(wrappedDomain, proxy);
         }


### PR DESCRIPTION
Using `Activator.CreateInstance` instead of `AppDomain.CreateInstanceAndUnwrap` based on obersvations from [this](http://stackoverflow.com/a/20978915/439094) SO answer.
Doing it this way doesn't make the AppDomain request full permissions.
However, `new ReflectionPermission(ReflectionPermissionFlag.MemberAccess)` is still required due to the nature of the assembly loader.